### PR TITLE
fix/feat pages publishing and setup GitHub Pages deployment with PR and prod/dev management

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -17,23 +17,17 @@ concurrency:
 # --- Job de build et déploiement ---
 jobs:
   build_resume:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04 # NOTE : If runner are in queue, update image to fix
+    container: 
+      image: yupiter/my-resume
+      options: --user 1001 # github actions user since default is node
     steps:
       - uses: actions/checkout@v4
-
-      # Run the prebuilt Docker image from Docker Hub
-      - name: Build HTML FR/EN in Docker
-        run: |
-          mkdir -p docs
-          docker run --rm -v ${{ github.workspace }}:/data -w /data \
-            yupiter/my-resume make PAGES_FOLDER=docs deploy_all
-
-
-      # Upload artifact outside the container
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+      - run: make build_html
+      - name: Upload HTML artifact
+        uses: actions/upload-artifact@v4
         with:
-          name: page-build
+          name: resume-html
           path: docs/
 
 
@@ -46,7 +40,7 @@ jobs:
       - name: Download build artifact
         uses: actions/download-artifact@v4
         with:
-          name: page-build
+          name: resume-html
           path: docs/
 
       - name: Prepare deployment folder

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           mkdir -p docs
           docker run --rm -v ${{ github.workspace }}:/data -w /data \
-            -e NPM_CONFIG_CACHE=/data/.npm-cache \
+            -e NPM_CONFIG_CACHE=/tmp/.npm-cache \
             yupiter/my-resume make PAGES_FOLDER=docs build_html
 
       # Upload artifact outside the container

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -25,8 +25,8 @@ jobs:
       - name: Build HTML FR/EN in Docker
         run: |
           mkdir -p docs
-          docker run --rm -v ${{ github.workspace }}:/data -w /data yupiter/my-resume \
-            make PAGES_FOLDER=docs build_html
+          docker run --rm -v ${{ github.workspace }}:/data -w /data --user $(id -u):$(id -g) \
+          yupiter/my-resume make PAGES_FOLDER=docs build_html
 
       # Upload artifact outside the container
       - name: Upload artifact

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -25,9 +25,10 @@ jobs:
       - name: Build HTML FR/EN in Docker
         run: |
           mkdir -p docs
-          docker run --rm -v ${{ github.workspace }}:/data -w /data \
+          docker run --rm -v ${{ github.workspace }}:/data -v /tmp/.npm-cache:/tmp/.npm-cache -w /data \
             -e NPM_CONFIG_CACHE=/tmp/.npm-cache \
             yupiter/my-resume make PAGES_FOLDER=docs build_html
+
 
       # Upload artifact outside the container
       - name: Upload artifact

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -19,22 +19,24 @@ concurrency:
 # --- Job de build et déploiement ---
 jobs:
   build_resume:
-    if: ${{ github.event_name != 'pull_request' || github.event.action == 'opened' }}
     runs-on: ubuntu-latest
-    container:
-      image: yupiter/my-resume
-      options: --user 1001
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build HTML via Makefile
-        run: make PAGES_FOLDER=docs build_html
+      # Run the prebuilt Docker image from Docker Hub
+      - name: Build HTML FR/EN in Docker
+        run: |
+          mkdir -p docs
+          docker run --rm -v ${{ github.workspace }}:/data -w /data yupiter/my-resume \
+            make PAGES_FOLDER=docs build_html
 
+      # Upload artifact outside the container
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
         with:
           name: page-build
           path: docs/
+
 
   deploy:
     needs: build_resume

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -6,9 +6,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, closed]  # opened = publication commentaire + déploiement, closed = cleanup PR
-  workflow_dispatch:
-
+    types: [opened, synchronize, closed] # opened = PR créée, synchronize = push sur PR, closed = cleanup  workflow_dispatch:
 permissions:
   contents: write
 

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,32 +1,76 @@
-name: Build resume html
-on: 
+name: Build and Deploy Resume HTML
+
+on:
   pull_request:
-  push: 
-    branches: 
+    branches:
+      - main
+  push:
+    branches:
       - main
   workflow_dispatch:
 
 permissions:
-  # Give the default GITHUB_TOKEN write permission to commit and push the changed files back to the repository.
   contents: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
   build_resume:
-    runs-on: ubuntu-24.04 # NOTE : If runner are in queue, update image to fix
-    container: 
+    runs-on: ubuntu-latest
+    container:
       image: yupiter/my-resume
-      options: --user 1001 # github actions user since default is node
+      options: --user 1001
     steps:
       - uses: actions/checkout@v4
-      - run: make build_html
-      - uses: stefanzweifel/git-auto-commit-action@v6 # Push html resulting files
-        with:
-          commit_message: "Upload html files to repo"
-          file_pattern: docs/*
 
+      - name: Build HTML via Makefile
+        run: make PAGES_FOLDER=docs build_html
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          name: page-build
+          path: docs/
+
+  deploy:
+    needs: build_resume
+    environment:
+      name: github-pages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: page-build
+          path: docs/
+
+      - name: Prepare deployment folder
+        run: |
+          BASE_DIR=deploy
+          mkdir -p $BASE_DIR
+
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            TARGET_DIR="$BASE_DIR/dev/pr-${{ github.event.pull_request.number }}"
+            if [ -d "$TARGET_DIR" ]; then
+              echo "Supprimer l'ancien build PR #${{ github.event.pull_request.number }}"
+              rm -rf "$TARGET_DIR"
+            fi
+          else
+            TARGET_DIR="$BASE_DIR/prod"
+            rm -rf "$TARGET_DIR"
+          fi
+
+          mkdir -p "$TARGET_DIR"
+          mv docs/* "$TARGET_DIR/"
+
+      - name: Generate indexes via Makefile
+        run: make DEPLOY_DIR="$BASE_DIR" TARGET_DIR="$TARGET_DIR" deploy_all
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./deploy

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,12 +1,12 @@
 name: Build and Deploy Resume HTML
 
+# Déclenchement du workflow
 on:
-  pull_request:
-    branches:
-      - main
   push:
     branches:
       - main
+  pull_request:
+    types: [opened, closed]  # opened = publication commentaire + déploiement, closed = cleanup PR
   workflow_dispatch:
 
 permissions:
@@ -16,8 +16,10 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
+# --- Job de build et déploiement ---
 jobs:
   build_resume:
+    if: ${{ github.event_name != 'pull_request' || github.event.action == 'opened' }}
     runs-on: ubuntu-latest
     container:
       image: yupiter/my-resume
@@ -50,18 +52,13 @@ jobs:
         run: |
           BASE_DIR=deploy
           mkdir -p $BASE_DIR
-
           if [ "${{ github.event_name }}" == "pull_request" ]; then
             TARGET_DIR="$BASE_DIR/dev/pr-${{ github.event.pull_request.number }}"
-            if [ -d "$TARGET_DIR" ]; then
-              echo "Supprimer l'ancien build PR #${{ github.event.pull_request.number }}"
-              rm -rf "$TARGET_DIR"
-            fi
+            rm -rf "$TARGET_DIR"
           else
             TARGET_DIR="$BASE_DIR/prod"
             rm -rf "$TARGET_DIR"
           fi
-
           mkdir -p "$TARGET_DIR"
           mv docs/* "$TARGET_DIR/"
 
@@ -74,3 +71,29 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./deploy
+
+      # Comment with dev link at opening
+      - name: Comment PR with dev link
+        if: ${{ github.event_name == 'pull_request' && github.event.action == 'opened' }}
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            🚀 La version de développement de cette PR est disponible ici :  
+            [PR #${{ github.event.pull_request.number }}](https://${{ github.repository_owner }}.github.io/${{ github.repository }}/dev/pr-${{ github.event.pull_request.number }}/)
+
+# --- Job cleanup closed PR  ---
+  cleanup_pr:
+    if: ${{ github.event_name == 'pull_request' && github.event.action == 'closed' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Remove PR deploy folder
+        run: |
+          BASE_DIR=deploy
+          TARGET_DIR="$BASE_DIR/dev/pr-${{ github.event.pull_request.number }}"
+          if [ -d "$TARGET_DIR" ]; then
+            echo "Supprimer les pages de la PR #${{ github.event.pull_request.number }}"
+            rm -rf "$TARGET_DIR"
+          fi

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -25,9 +25,8 @@ jobs:
       - name: Build HTML FR/EN in Docker
         run: |
           mkdir -p docs
-          docker run --rm -v ${{ github.workspace }}:/data -v /tmp/.npm-cache:/tmp/.npm-cache -w /data \
-            -e NPM_CONFIG_CACHE=/tmp/.npm-cache \
-            yupiter/my-resume make PAGES_FOLDER=docs build_html
+          docker run --rm -v ${{ github.workspace }}:/data -w /data \
+            yupiter/my-resume make PAGES_FOLDER=docs deploy_all
 
 
       # Upload artifact outside the container

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -25,8 +25,9 @@ jobs:
       - name: Build HTML FR/EN in Docker
         run: |
           mkdir -p docs
-          docker run --rm -v ${{ github.workspace }}:/data -w /data --user $(id -u):$(id -g) \
-          yupiter/my-resume make PAGES_FOLDER=docs build_html
+          docker run --rm -v ${{ github.workspace }}:/data -w /data \
+            -e NPM_CONFIG_CACHE=/data/.npm-cache \
+            yupiter/my-resume make PAGES_FOLDER=docs build_html
 
       # Upload artifact outside the container
       - name: Upload artifact

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM node:current-alpine3.15
+FROM node:current-alpine3.22
 
+RUN apk update
 RUN apk add make bash git
 RUN npm install -g resume-cli
 

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ fix-chrome-missing:
 	ca-certificates fonts-liberation libappindicator3-1 libasound2 libatk-bridge2.0-0 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libglib2.0-0 libgtk-3-0 libnspr4 libnss3 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 lsb-release wget xdg-utils
 
 install-theme:
-	npm install jsonresume-theme-$(JSON_RESUME_THEME)
+	npm install --prefix /tmp/.npm-cache jsonresume-theme-$(JSON_RESUME_THEME)
 
 # --- Build HTML ---
 build_html: install-theme

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ fix-chrome-missing:
 	ca-certificates fonts-liberation libappindicator3-1 libasound2 libatk-bridge2.0-0 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libglib2.0-0 libgtk-3-0 libnspr4 libnss3 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 lsb-release wget xdg-utils
 
 install-theme:
-	npm install --prefix /tmp/.npm-cache jsonresume-theme-$(JSON_RESUME_THEME)
+	npm install jsonresume-theme-$(JSON_RESUME_THEME)
 
 # --- Build HTML ---
 build_html: install-theme

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+DEPLOY_DIR ?= deploy
+TARGET_DIR ?= $(DEPLOY_DIR)/prod
+
 DOCKER_IMAGE_NAME=yupiter/my-resume
 JSON_RESUME_THEME=paper-plus-plus
 FILENAME=resume
@@ -8,6 +11,7 @@ SOURCE_FILE_ENGLISH=$(FILENAME)-EN.json
 OUTFILE_FRENCH=$(FILENAME)-FR
 OUTFILE_ENGLISH=$(FILENAME)-EN
 
+# --- Docker ---
 docker_build:
 	docker build . -t $(DOCKER_IMAGE_NAME)
 
@@ -15,29 +19,31 @@ docker_run:
 	docker run -v $(PWD):/data -it $(DOCKER_IMAGE_NAME) /bin/sh
 
 docker_push:
-	 docker push $(DOCKER_IMAGE_NAME)
+	docker push $(DOCKER_IMAGE_NAME)
 
+# --- Env / Theme ---
 install-env:
 	npm install -g resume-cli
 
-# See: https://github.com/alixaxel/chrome-aws-lambda/issues/164#issuecomment-737435267 
 fix-chrome-missing: 
 	ca-certificates fonts-liberation libappindicator3-1 libasound2 libatk-bridge2.0-0 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libglib2.0-0 libgtk-3-0 libnspr4 libnss3 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 lsb-release wget xdg-utils
 
 install-theme:
 	npm install jsonresume-theme-$(JSON_RESUME_THEME)
 
+# --- Build HTML ---
 build_html: install-theme
-# French
-	resume export $(PWD)/$(PAGES_FOLDER)/$(OUTFILE_ENGLISH) --format html -r $(SOURCE_FILE_ENGLISH) --theme $(JSON_RESUME_THEME)
 # English
-	resume export $(PWD)/$(PAGES_FOLDER)/$(OUTFILE_FRENCH) --format html -r $(SOURCE_FILE_FRENCH)  --theme $(JSON_RESUME_THEME)
-
-build_pdf: install-theme
+	resume export $(PWD)/$(PAGES_FOLDER)/$(OUTFILE_ENGLISH) --format html -r $(SOURCE_FILE_ENGLISH) --theme $(JSON_RESUME_THEME)
 # French
-	resume export $(OUTFILE_FRENCH) --format pdf -r $(SOURCE_FILE_FRENCH)  --theme $(JSON_RESUME_THEME)
+	resume export $(PWD)/$(PAGES_FOLDER)/$(OUTFILE_FRENCH) --format html -r $(SOURCE_FILE_FRENCH) --theme $(JSON_RESUME_THEME)
+
+# --- Build PDF ---
+build_pdf: install-theme
 # English
 	resume export $(OUTFILE_ENGLISH) --format pdf -r $(SOURCE_FILE_ENGLISH) --theme $(JSON_RESUME_THEME)
+# French
+	resume export $(OUTFILE_FRENCH) --format pdf -r $(SOURCE_FILE_FRENCH) --theme $(JSON_RESUME_THEME)
 
 from-gitconnected:
 	curl https://gitconnected.com/v1/portfolio/florian0410 | jq . > $(FILENAME)-gitconnected.json
@@ -45,3 +51,12 @@ from-gitconnected:
 # Only with official supported templates
 serve-resume:
 	resume serve --theme $(JSON_RESUME_THEME) -r $(SOURCE_FILE_FRENCH)
+
+# --- Build indexes individuels et globaux ---
+# TARGET_DIR = dossier individuel PR ou prod, ex: deploy/dev/pr-123 ou deploy/prod
+# DEPLOY_DIR = dossier racine pour les déploiements, ex: deploy
+generate_indexes:
+	./scripts/generate_indexes.sh $(DEPLOY_DIR) $(TARGET_DIR)
+
+# --- Build complet pour déploiement ---
+deploy_all: build_html generate_indexes

--- a/README.md
+++ b/README.md
@@ -13,17 +13,18 @@ For base json file: https://jsonresume.org/getting-started/, we will use this ba
 
 ## TODO | Ideas
 
-- Add an open source editor to ease resume creation
+[] Update cli to new third party https://github.com/rbardini/resumed
+[] Add an open source editor to ease resume creation
   - Validate version would create a PR ?
-- Link to my resume on webpage
-- Make repo public and keep gh-page public
-- Add a json-resume validator
-- Add skills directly to work experiences
-  - Skills should be more generalists while subskills should be more specifics. Skills = Devops, Big Data, Subskills = Hadoop, Terraform, Packer
-- Create a resume linter with best practices (max words for descriptions and others)
-  - Would be based on jsonresume scheme
-- Translation using gitlocalize ? https://gitlocalize.com/
-- Use Deepl API to translate some fields ? https://www.deepl.com/fr/docs-api/
-  - How to translate only certain fields ?
-- Field last update ?
-- Help me push these issues ?
+[] Link to my resume on webpage
+[x] Make repo public and keep gh-page public
+[] Add a json-resume validator
+[] Add skills directly to work experiences
+  [] Skills should be more generalists while subskills should be more specifics. Skills = Devops, Big Data, Subskills = Hadoop, Terraform, Packer
+[] Create a resume linter with best practices (max words for descriptions and others)
+  [] Would be based on jsonresume scheme
+[] Translation using gitlocalize ? https://gitlocalize.com/
+[] Use Deepl API to translate some fields ? https://www.deepl.com/fr/docs-api/
+  [] How to translate only certain fields ?
+[] Field last update ?
+[] Help me push these issues ?

--- a/scripts/generate_indexes.sh
+++ b/scripts/generate_indexes.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Usage: ./generate_indexes.sh BASE_DIR TARGET_DIR
+# BASE_DIR = dossier racine deploy (ex: deploy)
+# TARGET_DIR = dossier individuel PR ou prod (ex: deploy/dev/pr-123 ou deploy/prod)
+
+set -e
+
+BASE_DIR=$1
+TARGET_DIR=$2
+
+# --- Langues disponibles ---
+LANGS=("FR" "EN")
+
+# --- Génération index individuel ---
+mkdir -p "$TARGET_DIR"
+
+echo "<!DOCTYPE html>
+<html lang='fr'>
+<head>
+  <meta charset='UTF-8'>
+  <title>Résumé</title>
+</head>
+<body>
+<h1>Mon CV</h1>
+<p>" > "$TARGET_DIR/index.html"
+
+for lang in "${LANGS[@]}"; do
+  echo "<a href='resume-$lang.html'>$lang</a> | " >> "$TARGET_DIR/index.html"
+done
+
+# Supprimer le dernier " | "
+sed -i '$ s/ | $//' "$TARGET_DIR/index.html"
+
+echo "</p>
+</body>
+</html>" >> "$TARGET_DIR/index.html"
+
+echo "Index individuel généré dans $TARGET_DIR/index.html"
+
+# --- Génération index global ---
+GLOBAL_INDEX="$BASE_DIR/index.html"
+mkdir -p "$BASE_DIR"
+
+echo "<!DOCTYPE html>
+<html lang='fr'>
+<head>
+  <meta charset='UTF-8'>
+  <title>Hub de Développement</title>
+</head>
+<body>
+<h1>Hub de Développement</h1>
+<h2>Version Production</h2>
+<p>" > "$GLOBAL_INDEX"
+
+# Liens vers la prod
+for lang in "${LANGS[@]}"; do
+  echo "<a href='./prod/resume-$lang.html'>$lang</a> | " >> "$GLOBAL_INDEX"
+done
+sed -i '$ s/ | $//' "$GLOBAL_INDEX"
+echo "</p>
+<h2>Préviews PR</h2>
+<ul>" >> "$GLOBAL_INDEX"
+
+# Liens vers toutes les PR
+for prdir in "$BASE_DIR"/dev/pr-*; do
+  if [ -d "$prdir" ]; then
+    prnum=$(basename "$prdir" | sed 's/pr-//')
+    echo "<li>PR #$prnum : " >> "$GLOBAL_INDEX"
+    for lang in "${LANGS[@]}"; do
+      echo "<a href='./dev/pr-$prnum/resume-$lang.html'>$lang</a> " >> "$GLOBAL_INDEX"
+    done
+    echo "</li>" >> "$GLOBAL_INDEX"
+  fi
+done
+
+echo "</ul>
+</body>
+</html>" >> "$GLOBAL_INDEX"
+
+echo "Index global généré dans $GLOBAL_INDEX"


### PR DESCRIPTION
- Build HTML in both French and English via Makefile inside Docker container
- Generate individual PR indexes and global prod index via shell script
- Automatic deployment to GitHub Pages
  - Prod → /prod
  - Dev PR → /dev/pr-<num>
- Single automatic PR comment on creation with link to dev version
- Automatic cleanup of dev PR versions on PR closure without committing to main repository
- Default global index only shows prod version
- Avoid duplicate comments and keep dev versions “hidden” from public index
- DEPLOY_DIR and TARGET_DIR configurable for local testing
- Workflow simplified and clarified using Makefile and external shell script
